### PR TITLE
Fix lattice dimension bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,18 +1,21 @@
 #!/usr/bin/python3
 
+import os
+from os import path
+import math
+import subprocess
 from PIL import Image, ImageDraw
 from random import seed, sample
 from polylattice import PolyLattice
 from colors import palettes
-from os import path
-import subprocess
+
 
 # Possible resolution and their respective chunk size (TODO need to find better solution)
 res_chunk_map = {
     (3840, 2160): (240, 135),
     (1920, 1080): (160, 90),
     (1600, 900): (100, 100),
-    (1440, 900):(96, 100),
+    (1440, 900):(100, 100),
     (1360, 768): (136, 64),
     (1024, 768): (128, 96),
     (800, 600): (100, 100),
@@ -27,6 +30,8 @@ def main():
     ## Paths ##
     file_path = path.realpath(__file__)
     file_dir = file_path.rstrip("/main.py")
+    render = file_dir + "/renders"
+    os.makedirs(render, exist_ok=True)
     render_path = file_dir + "/renders/wallpaper.jpg"
 
     # Get resolution dynamically
@@ -56,10 +61,10 @@ def main():
     image_draw = ImageDraw.Draw(im)
 
     # Initialise a PolyLattice
-    poly_size_x = int(screen_size[0] / chunk_size[0])
-    poly_size_y = int(screen_size[1] / chunk_size[1])
+    poly_size_x = (screen_size[0] / chunk_size[0])
+    poly_size_y = (screen_size[1] / chunk_size[1])
 
-    polylattice = PolyLattice(im.size, (poly_size_x, poly_size_y))
+    polylattice = PolyLattice(im.size, (math.ceil(poly_size_x), math.ceil(poly_size_y)))
     polylattice.initialise(separate_in_triangles=True)
 
     # Choose two colors from the palette

--- a/polylattice.py
+++ b/polylattice.py
@@ -38,16 +38,22 @@ class PolyLattice:
         # It is not simply image_size[0] and [1] because the image is not always
         # perfectly divided by the polygons
 
-        # TODO do it
 
         # Mutate each vertex that is not in one border of the image
+        # We use the fact that a mutated vertex cannot be inside the screen
+        # if its original value was outside
         for vertex in self.vertices.values():
-            if vertex.coordinates[0] != 0 and \
-               vertex.coordinates[0] != self.image_size[0] and \
-               vertex.coordinates[1] != 0 and \
-               vertex.coordinates[1] != self.image_size[1]:
-
+            init_x = vertex.coordinates[0]
+            init_y = vertex.coordinates[1]
+            if init_x != 0 and init_y != 0:
                 vertex.random_mutation(intensity)
+            if (vertex.coordinates[0] < self.image_size[0] and \
+               init_x >= self.image_size[0]) or \
+               (vertex.coordinates[1] < self.image_size[1] and \
+               init_y >= self.image_size[1]):
+                    # Revert mutation
+                    vertex.coordinates = (init_x, init_y)
+    
 
     def randomise_colors(self):
         """ Randomise the color of each polygon """


### PR DESCRIPTION
This addition fixes bug #2 . We can now get rid of the dimension hash map because reasonable chunk size should yield the expected result. (Choosing `(5,500)` or similar extreme values might give some unexpected visual artifacts). The mutation is now always applied, but is reverted if a mutated outside vertex was sent back inside the screen (producing black triangles).

Another way of fixing this problem could have been to have two different mutation functions (`mutate_x`, `mutate_y`) and apply both them on the vertices inside the screen, but apply only one of them to the vertices outside the screen.
